### PR TITLE
Pin `mypy` and remove dependency on `build`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 -e .
 
 black==23.3.0
+mypy==1.4.0
 pytest==7.4.0
-build
-mypy


### PR DESCRIPTION
Removes the `build` dependency since developers should never actually need it. Publishing to pypy will always be done via Actions so we can just pip install it in that environment when needed.