### PR TITLE
Configure linting and setup linting workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+max-line-length = 90
+# Ignore non PEP 8 compliant rules as suggested by black
+extend-ignore =
+    E203,  # https://github.com/psf/black/blob/master/docs/the_black_code_style.md#slices
+    E501,
+    B017

--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,3 @@
 [flake8]
-max-line-length = 90
-# Ignore non PEP 8 compliant rules as suggested by black
-extend-ignore =
-    E203,  # https://github.com/psf/black/blob/master/docs/the_black_code_style.md#slices
-    E501,
-    B017
+max-line-length = 88
+extend-ignore = E203

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  main:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint
+        run: ./scripts/lint.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,13 +12,16 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Python
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -121,7 +121,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -3,5 +3,5 @@ name = "python"
 auto-format = true
 
 [language.formatter]
-command = "black"
-args = ["--quiet", "-"]
+command = "sh"
+args = ["-c", "black --quiet - | isort -"]

--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -2,18 +2,14 @@
 name = "python"
 auto-format = true
 
-[language.config.pylsp]
+[language.formatter]
+command = "sh"
+args = ["-c", "black --quiet - | isort -"]
+
+[language-server.pylsp.config.pylsp]
 configurationSources = ["flake8"]
 plugins.flake8.enabled = true
 plugins.pycodestyle.enabled = false
 plugins.mccabe.enabled = false
 plugins.pyflakes.enabled = false
-
-[language.config.pylsp.plugins.pydocstyle]
-enabled = true
-convention = "google"
-matchDir = "trnpy|tests"
-
-[language.formatter]
-command = "sh"
-args = ["-c", "black --quiet - | isort -"]
+plugins.pydocstyle = {"enabled" = true, "convention" = "google", "matchDir" = "trnpy|tests"}

--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -6,6 +6,7 @@ auto-format = true
 configurationSources = ["flake8"]
 plugins.flake8.enabled = true
 plugins.pycodestyle.enabled = false
+plugins.pydocstyle.enabled = true
 plugins.mccabe.enabled = false
 plugins.pyflakes.enabled = false
 

--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -6,9 +6,13 @@ auto-format = true
 configurationSources = ["flake8"]
 plugins.flake8.enabled = true
 plugins.pycodestyle.enabled = false
-plugins.pydocstyle.enabled = true
 plugins.mccabe.enabled = false
 plugins.pyflakes.enabled = false
+
+[language.config.pylsp.plugins.pydocstyle]
+enabled = true
+convention = "google"
+matchDir = "trnpy|tests"
 
 [language.formatter]
 command = "sh"

--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -2,6 +2,13 @@
 name = "python"
 auto-format = true
 
+[language.config.pylsp]
+configurationSources = ["flake8"]
+plugins.flake8.enabled = true
+plugins.pycodestyle.enabled = false
+plugins.mccabe.enabled = false
+plugins.pyflakes.enabled = false
+
 [language.formatter]
 command = "sh"
 args = ["-c", "black --quiet - | isort -"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ profile = "black"
 
 [tool.pydocstyle]
 convention = "google"
+match-dir = "trnpy|tests"
 
 [tool.pytest.ini_options]
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ classifiers = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.isort]
+profile = "black"
+
 [tool.pytest.ini_options]
 addopts = [
   "--import-mode=importlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ build-backend = "hatchling.build"
 [tool.isort]
 profile = "black"
 
+[tool.pydocstyle]
+convention = "google"
+
 [tool.pytest.ini_options]
 addopts = [
   "--import-mode=importlib",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -e .
 
 black==23.3.0
+isort==5.12.0
 mypy==1.4.1
 pytest==7.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ black==23.3.0
 flake8==6.0.0
 isort==5.12.0
 mypy==1.4.1
+pydocstyle[toml]==6.3.0
 pytest==7.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 -e .
 
 black==23.3.0
+flake8==6.0.0
 isort==5.12.0
 mypy==1.4.1
 pytest==7.4.0

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 set -euxo pipefail
 
-black --target-version py37 --check .
+black --target-version py311 --check .
 isort --profile black --check --diff trnpy/ tests/
+flake8 trnpy/ tests/

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+set -euxo pipefail
+
+black --target-version py37 --check .
+isort --profile black --check --diff trnpy/ tests/

--- a/tests/test_trnsys.py
+++ b/tests/test_trnsys.py
@@ -3,21 +3,20 @@ from pathlib import Path
 
 import pytest
 
-
-from trnpy.trnsys.simulation import Simulation
-from trnpy.trnsys.lib import (
-    TrnsysLib,
-    TrnsysDirectories,
-    StepForwardReturn,
-    GetOutputValueReturn,
-    track_lib_path,
-)
 from trnpy.exceptions import (
     DuplicateLibraryError,
-    TrnsysStepForwardError,
     TrnsysGetOutputValueError,
     TrnsysSetInputValueError,
+    TrnsysStepForwardError,
 )
+from trnpy.trnsys.lib import (
+    GetOutputValueReturn,
+    StepForwardReturn,
+    TrnsysDirectories,
+    TrnsysLib,
+    track_lib_path,
+)
+from trnpy.trnsys.simulation import Simulation
 
 
 class MockTrnsysLib(TrnsysLib):

--- a/trnpy/trnsys/lib.py
+++ b/trnpy/trnsys/lib.py
@@ -11,9 +11,7 @@ from ..exceptions import DuplicateLibraryError
 
 @dataclass
 class TrnsysDirectories:
-    """
-    Represents the directory paths required by TRNSYS.
-    """
+    """Represents the directory paths required by TRNSYS."""
 
     root: Path
     exe: Path

--- a/trnpy/trnsys/lib.py
+++ b/trnpy/trnsys/lib.py
@@ -48,7 +48,6 @@ def _track_lib_path(lib_path: Path, tracked_paths: set):
     Raises:
         DuplicateLibraryError: If the file at `lib_path` is already in use.
     """
-
     if lib_path in tracked_paths:
         raise DuplicateLibraryError(f"The TRNSYS lib '{lib_path}' is already loaded")
     tracked_paths.add(lib_path)

--- a/trnpy/trnsys/lib.py
+++ b/trnpy/trnsys/lib.py
@@ -2,11 +2,9 @@
 
 import ctypes as ct
 import functools
-from collections import namedtuple
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NamedTuple
-
 
 from ..exceptions import DuplicateLibraryError
 

--- a/trnpy/trnsys/simulation.py
+++ b/trnpy/trnsys/simulation.py
@@ -3,14 +3,14 @@
 import os
 from pathlib import Path
 
-from .lib import TrnsysLib, LoadedTrnsysLib, TrnsysDirectories
 from ..exceptions import (
-    TrnsysSetDirectoriesError,
-    TrnsysLoadInputFileError,
-    TrnsysStepForwardError,
     TrnsysGetOutputValueError,
+    TrnsysLoadInputFileError,
+    TrnsysSetDirectoriesError,
     TrnsysSetInputValueError,
+    TrnsysStepForwardError,
 )
+from .lib import LoadedTrnsysLib, TrnsysDirectories, TrnsysLib
 
 
 class Simulation:


### PR DESCRIPTION
Configures linting for the project. It uses the following:

- isort: for sorting imports
- flake8: for pep8 compliance and a few other things
- black: actually a formatter, but we check that this format is actually adhered to
- pydocstyle: to check that documentation is properly formatted

All of these have been included in the helix editor configuration included in the project.

All except pydocstyle are checked in CI. Once we settle on some configuration
for that, we should also include it in our CI check.

I'll deal with mypy stuff in a separate PR, as I suspect that will be more involved.
