### PR TITLE
Add class method to TrnsysDirectories

### DIFF
--- a/tests/test_trnsys.py
+++ b/tests/test_trnsys.py
@@ -98,11 +98,10 @@ def new_sim(*, lib_state: dict = {}):
     Args:
         lib_state (dict, optional): If provided, passed directly to `MockTrnsysLib`.
     """
-    return Simulation(
-        MockTrnsysLib(**lib_state),
-        TrnsysDirectories("", "", ""),
-        Path(""),
-    )
+    lib = MockTrnsysLib(**lib_state)
+    dirs = TrnsysDirectories.from_single_path(Path(""))
+    input_file = Path("")
+    return Simulation(lib, dirs, input_file)
 
 
 def test_track_lib_path_raises_duplicate_error_on_same_path():

--- a/trnpy/trnsys/lib.py
+++ b/trnpy/trnsys/lib.py
@@ -17,6 +17,15 @@ class TrnsysDirectories:
     exe: Path
     user_lib: Path
 
+    @classmethod
+    def from_single_path(cls, path: Path) -> "TrnsysDirectories":
+        """Create a TrnsysDirectories instance from a single path.
+
+        Args:
+            path (Path): The path to use for all TRNSYS directories.
+        """
+        return cls(path, path, path)
+
 
 class StepForwardReturn(NamedTuple):
     """The return value of `TrnsysLib.step_forward`.


### PR DESCRIPTION
This PR adds a class method to the `TrnsysDirectories` dataclass to make it easier to set all directories to a single path.  It also uses this method to fix a type error that existed in the test code.