### PR TITLE
MyPy static type-checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,15 @@ build-backend = "hatchling.build"
 [tool.isort]
 profile = "black"
 
+[tool.mypy]
+strict = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+allow_untyped_defs = true
+allow_incomplete_defs = true
+allow_untyped_calls = true
+
 [tool.pydocstyle]
 convention = "google"
 match-dir = "trnpy|tests"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 set -euxo pipefail
 
+mypy -p trnpy -p tests
 black --target-version py311 --check .
 isort --profile black --check --diff trnpy/ tests/
 flake8 trnpy/ tests/

--- a/tests/test_trnsys.py
+++ b/tests/test_trnsys.py
@@ -1,5 +1,7 @@
 import math
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, Optional
 
 import pytest
 
@@ -19,6 +21,23 @@ from trnpy.trnsys.lib import (
 from trnpy.trnsys.simulation import Simulation
 
 
+@dataclass(frozen=True)
+class UnitState:
+    """State of a unit in the simulation.
+
+    Attributes:
+        parameters (list of floats): Current parameter values.
+        inputs (list of floats): Current input values.
+        outputs (list of floats): Current output values.
+        derivatives (list of floats): Current derivative values.
+    """
+
+    parameters: list[float] = field(default_factory=list)
+    inputs: list[float] = field(default_factory=list)
+    outputs: list[float] = field(default_factory=list)
+    derivatives: list[float] = field(default_factory=list)
+
+
 class MockTrnsysLib(TrnsysLib):
     def __init__(
         self,
@@ -27,7 +46,7 @@ class MockTrnsysLib(TrnsysLib):
         final_time: float = 10,
         time_step: float = 1,
         current_time: float = 0,
-        units: dict = {},
+        units: Optional[dict[int, UnitState]] = None,
     ):
         """Create a new mocked TRNSYS library.
 
@@ -37,19 +56,13 @@ class MockTrnsysLib(TrnsysLib):
             time_step (float, optional): The simulation time step.  Defaults to 1.
             current_time (float, optional): The current simulation time.  Defaults to 0.
             units (dict, optional): The assumed state of any units in the
-                simualation, keyed by unit number.  Each unit is represented as
-                a dict with any of the following keys, each of which map to a
-                list of floats for that item:
-                    - "parameters" (list of floats): Current parameter values.
-                    - "inputs" (list of floats): Current input values.
-                    - "outputs" (list of floats): Current output values.
-                    - "derivatives" (list of floats): Current derivative values.
+                simualation, keyed by unit number.
         """
         self._start_time = start_time
         self._final_time = final_time
         self._time_step = time_step
         self._current_time = current_time
-        self._units = units
+        self._units = units if units else {}
 
     def _is_at_final_time(self):
         """Check if simulation is at final time.
@@ -74,7 +87,7 @@ class MockTrnsysLib(TrnsysLib):
     def get_output_value(self, unit: int, output_number: int) -> GetOutputValueReturn:
         if unit not in self._units:
             return GetOutputValueReturn(math.nan, 1)
-        unit_outputs = self._units[unit].get("outputs", [])
+        unit_outputs = self._units[unit].outputs
         index = output_number - 1
         if index >= len(unit_outputs):
             return GetOutputValueReturn(math.nan, 2)
@@ -84,7 +97,7 @@ class MockTrnsysLib(TrnsysLib):
     def set_input_value(self, unit: int, input_number: int, value: float) -> int:
         if unit not in self._units:
             return 1
-        unit_inputs = self._units[unit].get("inputs", [])
+        unit_inputs = self._units[unit].inputs
         index = input_number - 1
         if index >= len(unit_inputs):
             return 2
@@ -92,13 +105,13 @@ class MockTrnsysLib(TrnsysLib):
         return 0
 
 
-def new_sim(*, lib_state: dict = {}):
+def new_sim(*, lib_state: Optional[dict[str, Any]] = None):
     """Create a new simulation with a mocked TrnsysLib.
 
     Args:
         lib_state (dict, optional): If provided, passed directly to `MockTrnsysLib`.
     """
-    lib = MockTrnsysLib(**lib_state)
+    lib = MockTrnsysLib(**(lib_state if lib_state else {}))
     dirs = TrnsysDirectories.from_single_path(Path(""))
     input_file = Path("")
     return Simulation(lib, dirs, input_file)
@@ -128,13 +141,13 @@ def test_getting_output_values():
     assert err.value.error_code == 1
 
     # Unit now present but output number not available
-    sim = new_sim(lib_state={"units": {23: {"outputs": [1, 2]}}})
+    sim = new_sim(lib_state={"units": {23: UnitState(outputs=[1, 2])}})
     with pytest.raises(TrnsysGetOutputValueError) as err:
         sim.get_output_value(unit=23, output_number=3)
     assert err.value.error_code == 2
 
     # Unit and output number now available
-    sim = new_sim(lib_state={"units": {23: {"outputs": [1, 2, 3, 4, 5]}}})
+    sim = new_sim(lib_state={"units": {23: UnitState(outputs=[1, 2, 3, 4, 5])}})
     value = sim.get_output_value(unit=23, output_number=5)
     assert value == 5
 
@@ -147,10 +160,10 @@ def test_setting_input_values():
     assert err.value.error_code == 1
 
     # Unit now present but input number not available
-    sim = new_sim(lib_state={"units": {23: {"inputs": [1, 2]}}})
+    sim = new_sim(lib_state={"units": {23: UnitState(inputs=[1, 2])}})
     with pytest.raises(TrnsysSetInputValueError) as err:
         sim.set_input_value(unit=23, input_number=3, value=42)
     assert err.value.error_code == 2
 
     # Unit and input number now available
-    sim = new_sim(lib_state={"units": {23: {"inputs": [1, 2, 3]}}})
+    sim = new_sim(lib_state={"units": {23: UnitState(inputs=[1, 2, 3])}})

--- a/trnpy/exceptions.py
+++ b/trnpy/exceptions.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+
 class DuplicateLibraryError(Exception):
     """Raised when a library file has already been loaded."""
 
@@ -9,12 +12,10 @@ class SimulationError(Exception):
 class TrnsysError(Exception):
     """Represents an error raised by TRNSYS."""
 
-    def __init__(self, messages: dict, error_code: int):
-        message = messages.get(
-            error_code,
-            f"An unknown TRNSYS error ({error_code}) occurred.",
+    def __init__(self, error_code: int, message: Optional[str] = None):
+        super().__init__(
+            message if message else f"An unknown TRNSYS error ({error_code}) occurred."
         )
-        super().__init__(message)
         self.error_code = error_code
 
 
@@ -28,7 +29,7 @@ class TrnsysSetDirectoriesError(TrnsysError):
             5: "user lib directory string is too long",
             6: "user lib directory does not exist",
         }
-        super().__init__(messages, error_code)
+        super().__init__(error_code, messages.get(error_code))
 
 
 class TrnsysLoadInputFileError(TrnsysError):
@@ -39,7 +40,7 @@ class TrnsysLoadInputFileError(TrnsysError):
             3: "list file cannot be opened for writing",
             4: "input file cannot be opened for reading",
         }
-        super().__init__(messages, error_code)
+        super().__init__(error_code, messages.get(error_code))
 
 
 class TrnsysStepForwardError(TrnsysError):
@@ -47,7 +48,7 @@ class TrnsysStepForwardError(TrnsysError):
         messages = {
             1: "simulation has reached its final time",
         }
-        super().__init__(messages, error_code)
+        super().__init__(error_code, messages.get(error_code))
 
 
 class TrnsysGetOutputValueError(TrnsysError):
@@ -56,7 +57,7 @@ class TrnsysGetOutputValueError(TrnsysError):
             1: "unit is not present in the deck",
             2: "output number is not valid for this unit",
         }
-        super().__init__(messages, error_code)
+        super().__init__(error_code, messages.get(error_code))
 
 
 class TrnsysSetInputValueError(TrnsysError):
@@ -65,4 +66,4 @@ class TrnsysSetInputValueError(TrnsysError):
             1: "unit is not present in the deck",
             2: "input number is not valid for this unit",
         }
-        super().__init__(messages, error_code)
+        super().__init__(error_code, messages.get(error_code))

--- a/trnpy/trnsys/lib.py
+++ b/trnpy/trnsys/lib.py
@@ -51,7 +51,7 @@ class GetOutputValueReturn(NamedTuple):
     error: int
 
 
-def _track_lib_path(lib_path: Path, tracked_paths: set):
+def _track_lib_path(lib_path: Path, tracked_paths: set[Path]) -> None:
     """Track TRNSYS lib file paths.
 
     Raises:

--- a/trnpy/trnsys/simulation.py
+++ b/trnpy/trnsys/simulation.py
@@ -119,7 +119,7 @@ class Simulation:
 
         return value
 
-    def set_input_value(self, *, unit: int, input_number: int, value: float):
+    def set_input_value(self, *, unit: int, input_number: int, value: float) -> None:
         """Set an input value for a unit.
 
         Args:

--- a/trnpy/trnsys/simulation.py
+++ b/trnpy/trnsys/simulation.py
@@ -19,8 +19,8 @@ class Simulation:
     @classmethod
     def new(
         cls,
-        trnsys_lib: str | os.PathLike,
-        input_file: str | os.PathLike,
+        trnsys_lib: str | os.PathLike[str],
+        input_file: str | os.PathLike[str],
     ) -> "Simulation":
         """Create a new TRNSYS simulation.
 


### PR DESCRIPTION
Uses MyPy for static type-checking. Builds will now fail if MyPy detects any issues.

I did a bit of refactoring to fix issues reported by MyPy, namely a `UnitState` dataclass that makes some test code a bit more explicit, and a slight rejiggering of the base error to make it more broadly useable.