### PR TITLE
Don't pin black to support Python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e .
 
-black==23.3.0
+black>=23.3.0
 coverage==7.2.7
 flake8>=5.0.4
 isort>=5.11.5


### PR DESCRIPTION
Should resolve issues in https://github.com/isentropic-dev/trnpy/pull/24