### PR TITLE
Get current simulation time

### DIFF
--- a/trnpy/exceptions.py
+++ b/trnpy/exceptions.py
@@ -9,6 +9,14 @@ class SimulationError(Exception):
     """Raised when a simulation reports a fatal error."""
 
 
+class SimulationNotInitializedError(Exception):
+    """Raised when a simulation has not been initialized.
+
+    This error occurs when functions that control or access
+    a simulation are called before it has been initialized.
+    """
+
+
 class TrnsysError(Exception):
     """Represents an error raised by TRNSYS."""
 

--- a/trnpy/trnsys/lib.py
+++ b/trnpy/trnsys/lib.py
@@ -122,7 +122,7 @@ class TrnsysLib:
         """Return the current time of the simulation.
 
         Returns:
-            TrnsysError
+            SimulationNotInitializedError
         """
         raise NotImplementedError
 

--- a/trnpy/trnsys/lib.py
+++ b/trnpy/trnsys/lib.py
@@ -122,7 +122,7 @@ class TrnsysLib:
         """Return the current time of the simulation.
 
         Returns:
-            SimulationNotInitializedError
+            GetCurrentTimeReturn
         """
         raise NotImplementedError
 

--- a/trnpy/trnsys/lib.py
+++ b/trnpy/trnsys/lib.py
@@ -39,6 +39,18 @@ class StepForwardReturn(NamedTuple):
     error: int
 
 
+class GetCurrentTimeReturn(NamedTuple):
+    """The return value of `TrnsysLib.get_current_time`.
+
+    Attributes:
+        value (float): The current simulation time reported by TRNSYS.
+        error (int): Error code reported by TRNSYS, with 0 indicating a successful call.
+    """
+
+    value: float
+    error: int
+
+
 class GetOutputValueReturn(NamedTuple):
     """The return value of `TrnsysLib.get_output_value`.
 
@@ -106,6 +118,14 @@ class TrnsysLib:
         """
         raise NotImplementedError
 
+    def get_current_time(self) -> GetCurrentTimeReturn:
+        """Return the current time of the simulation.
+
+        Returns:
+            TrnsysError
+        """
+        raise NotImplementedError
+
     def get_output_value(self, unit: int, output_number: int) -> GetOutputValueReturn:
         """Return the output value of a unit.
 
@@ -164,6 +184,10 @@ class LoadedTrnsysLib(TrnsysLib):
             ct.c_int,  # number of steps
             ct.POINTER(ct.c_int),  # error code (by reference)
         ]
+        self.lib.apiGetCurrentTime.restype = ct.c_double
+        self.lib.apiGetCurrentTime.argtypes = [
+            ct.POINTER(ct.c_int),  # error code (by reference)
+        ]
         self.lib.apiGetOutputValue.restype = ct.c_double
         self.lib.apiGetOutputValue.argtypes = [
             ct.c_int,  # unit number
@@ -212,6 +236,15 @@ class LoadedTrnsysLib(TrnsysLib):
         error = ct.c_int(0)
         done = self.lib.apiStepForward(steps, error)
         return StepForwardReturn(done, error.value)
+
+    def get_current_time(self) -> GetCurrentTimeReturn:
+        """Return the current time of the simulation.
+
+        Refer to the documentation of `TrnsysLib.get_current_time` for more details.
+        """
+        error = ct.c_int(0)
+        value = self.lib.apiGetCurrentTime(error)
+        return GetCurrentTimeReturn(value, error.value)
 
     def get_output_value(self, unit: int, output_number: int) -> GetOutputValueReturn:
         """Return the output value of a unit.

--- a/trnpy/trnsys/simulation.py
+++ b/trnpy/trnsys/simulation.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import List, Union
 
 from ..exceptions import (
-    TrnsysError,
+    SimulationNotInitializedError,
     TrnsysGetOutputValueError,
     TrnsysLoadInputFileError,
     TrnsysSetDirectoriesError,
@@ -122,11 +122,11 @@ class Simulation:
             float: The current simulation time.
 
         Raises:
-            TrnsysGetCurrentTimeError
+            SimulationNotInitializedError
         """
         (value, error_code) = self.lib.get_current_time()
         if error_code:
-            raise TrnsysError(error_code)
+            raise SimulationNotInitializedError
 
         return value
 

--- a/trnpy/trnsys/simulation.py
+++ b/trnpy/trnsys/simulation.py
@@ -11,6 +11,7 @@ from ..exceptions import (
     TrnsysSetDirectoriesError,
     TrnsysSetInputValueError,
     TrnsysStepForwardError,
+    TrnsysError,
 )
 from .lib import LoadedTrnsysLib, TrnsysDirectories, TrnsysLib
 

--- a/trnpy/trnsys/simulation.py
+++ b/trnpy/trnsys/simulation.py
@@ -6,12 +6,12 @@ from pathlib import Path
 from typing import List, Union
 
 from ..exceptions import (
+    TrnsysError,
     TrnsysGetOutputValueError,
     TrnsysLoadInputFileError,
     TrnsysSetDirectoriesError,
     TrnsysSetInputValueError,
     TrnsysStepForwardError,
-    TrnsysError,
 )
 from .lib import LoadedTrnsysLib, TrnsysDirectories, TrnsysLib
 

--- a/trnpy/trnsys/simulation.py
+++ b/trnpy/trnsys/simulation.py
@@ -114,6 +114,21 @@ class Simulation:
 
         return done
 
+    def get_current_time(self) -> float:
+        """Return the current time of the simulation.
+
+        Returns:
+            float: The current simulation time.
+
+        Raises:
+            TrnsysGetCurrentTimeError
+        """
+        (value, error_code) = self.lib.get_current_time()
+        if error_code:
+            raise TrnsysError
+
+        return value
+
     def get_output_value(self, *, unit: int, output_number: int) -> float:
         """Return the current output value of a unit.
 

--- a/trnpy/trnsys/simulation.py
+++ b/trnpy/trnsys/simulation.py
@@ -126,7 +126,7 @@ class Simulation:
         """
         (value, error_code) = self.lib.get_current_time()
         if error_code:
-            raise TrnsysError
+            raise TrnsysError(error_code)
 
         return value
 


### PR DESCRIPTION
This PR exposes the `apiGetCurrentTime` method.  There are a few more of these types of functions to add:

```
get_start_time()
get_stop_time()
get_time_step()
get_current_step()
get_total_steps()
```

I think when we add those functions in a future PR we should use a more generic `TrnsysReturnValue` class rather than the current approach of having a specific return class for each function.

The tracking issue for adding those functions is #28 