### PR TITLE
Store all requirements in pyproject.toml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -e ".[lint,typing]"
       - name: Lint
         run: ./scripts/lint.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install -e ".[lint,typing]"
+          pip install -e ".[lint,test,typing]"
       - name: Lint
         run: ./scripts/lint.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -e ".[test]"
       - name: Test
         shell: bash
         run: ./scripts/test.sh

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You should see `(trnpy)` at the beginning of your command prompt, indicating tha
 4. With the virtual environment activated, you can now install the project requirements:
 
 ```
-pip install -r requirements.txt
+pip install -e ".[lint,test,typing]"
 ```
 
 This will install all the required packages specified in the `requirements.txt` file into your virtual environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,10 @@
 name = "trnpy"
 version = "0.0.1"
 authors = [
-  { name="John Dyreby", email="john@isentropic.dev" },
-  { name="Greg Troszak", email="greg@isentropic.dev" },
+  { name = "John Dyreby", email = "john@isentropic.dev" },
+  { name = "Greg Troszak", email = "greg@isentropic.dev" },
 ]
-description = "A Python wrapper for TRNSYS"
+description = "A Python wrapper for transient simulations."
 readme = "README.md"
 requires-python = ">=3.7"
 classifiers = [
@@ -16,6 +16,16 @@ classifiers = [
 
 [project.urls]
 "Homepage" = "https://github.com/isentropic-dev/trnpy"
+
+[project.optional-dependencies]
+lint = [
+  "black == 23.3.0",
+  "flake8 >= 5.0.4",
+  "isort >= 5.11.5",
+  "pydocstyle[toml] == 6.3.0",
+]
+test = ["coverage == 7.2.7", "pytest == 7.4.0"]
+typing = ["mypy == 1.4.1"]
 
 [build-system]
 requires = ["hatchling"]
@@ -39,6 +49,4 @@ convention = "google"
 match-dir = "trnpy|tests"
 
 [tool.pytest.ini_options]
-addopts = [
-  "--import-mode=importlib",
-]
+addopts = ["--import-mode=importlib"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
--e .
-
-black>=23.3.0
-coverage>=7.2.7
-flake8>=5.0.4
-isort>=5.11.5
-mypy>=1.4.1
-pydocstyle[toml]==6.3.0
-pytest==7.4.0


### PR DESCRIPTION
Removes requirements.txt in favor of using pyproject.toml for everything.