### PR TITLE
Add a pipeline for publishing to PyPi

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     paths-ignore:
-    - '**/*.md'
+    - '**.md'
     - .gitignore
 
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish
+
+on:
+  # workflow_run:
+  #   workflows:
+  #     - Test
+  #   types:
+  #     - completed
+  #   branches:
+  #     - main
+  push:
+    branches:
+      - publish-pipeline
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build and inspect package 
+      - uses: hynek/build-and-inspect-python-package@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build and inspect package 
-      - uses: hynek/build-and-inspect-python-package@v1
+        uses: hynek/build-and-inspect-python-package@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,13 @@
 name: Publish
 
 on:
-  # workflow_run:
-  #   workflows:
-  #     - Test
-  #   types:
-  #     - completed
-  #   branches:
-  #     - main
-  push:
+  workflow_run:
+    workflows:
+      - Test
+    types:
+      - completed
     branches:
-      - publish-pipeline
+      - main
   release:
     types:
       - released
@@ -21,7 +18,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -30,7 +27,7 @@ jobs:
   release-dev:
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/publish-pipeline'
+    if: github.ref == 'refs/heads/main'
     environment: test-pypi
     steps:
       - name: Download packages
@@ -55,5 +52,5 @@ jobs:
         with:
           name: Packages
           path: dist
-      - name: Upload to Test PyPI
+      - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ on:
     branches:
       - publish-pipeline
 
+permissions:
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,10 +24,10 @@ jobs:
       - name: Build and inspect package 
         uses: hynek/build-and-inspect-python-package@v1
   release-dev:
-    environment: test-pypi
-    if: github.ref == 'refs/heads/publish-pipeline'
-    needs: build
     runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/publish-pipeline'
+    environment: test-pypi
     steps:
       - name: Download packages
         uses: actions/download-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,3 +20,18 @@ jobs:
         uses: actions/checkout@v3
       - name: Build and inspect package 
         uses: hynek/build-and-inspect-python-package@v1
+  release-dev:
+    environment: test-pypi
+    if: github.ref == 'refs/heads/publish-pipeline'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download packages
+        uses: actions/download-artifact@v3
+        with:
+          name: Packages
+          path: dist
+      - name: Upload to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,9 @@ on:
   push:
     branches:
       - publish-pipeline
+  release:
+    types:
+      - released
 
 permissions:
   id-token: write
@@ -18,6 +21,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -38,3 +42,18 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: |
+      github.event_name == 'release' &&
+      github.event.action == 'released'
+    environment: pypi
+    steps:
+      - name: Download packages
+        uses: actions/download-artifact@v3
+        with:
+          name: Packages
+          path: dist
+      - name: Upload to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     paths-ignore:
-    - '**/*.md'
+    - '**.md'
     - .gitignore
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# How to contribute to trnpy
+# How to contribute to TrnPy
 
 ### First time setup in your local environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@
         $ git config --global user.name 'your name'
         $ git config --global user.email 'your email'
 
--   Fork trnpy to your GitHub account by clicking the `Fork`_ button.
+-   Fork TrnPy to your GitHub account by clicking the `Fork`_ button.
 -   `Clone`_ your fork locally, replacing ``your-username`` in the command below with
     your actual username.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@
          > py -3 -m venv .venv --prompt trnpy
          > .venv\Scripts\activate
 
--   Install the development dependencies, then install Flask in editable mode.
+-   Install the development dependencies, then install TrnPy in editable mode.
 
     .. code-block:: text
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# How to contribute to trnpy
+
+### First time setup in your local environment
+
+-   Make sure you have a `GitHub account`_.
+-   Download and install the `latest version of git`_.
+-   Configure git with your `username`_ and `email`_.
+
+    .. code-block:: text
+
+        $ git config --global user.name 'your name'
+        $ git config --global user.email 'your email'
+
+-   Fork trnpy to your GitHub account by clicking the `Fork`_ button.
+-   `Clone`_ your fork locally, replacing ``your-username`` in the command below with
+    your actual username.
+
+    .. code-block:: text
+
+        $ git clone https://github.com/your-username/trnpy
+        $ cd trnpy
+
+-   Create a virtualenv. Use the latest version of Python.
+
+    - Linux/macOS
+
+      .. code-block:: text
+
+         $ python3 -m venv .venv --prompt trnpy
+         $ source .venv/bin/activate
+
+    - Windows
+
+      .. code-block:: text
+
+         > py -3 -m venv .venv --prompt trnpy
+         > .venv\Scripts\activate
+
+-   Install the development dependencies, then install Flask in editable mode.
+
+    .. code-block:: text
+
+        $ python -m pip install -U pip
+        $ pip install -e ".[lint,test,typing]"
+
+.. _GitHub account: https://github.com/join
+.. _latest version of git: https://git-scm.com/downloads
+.. _username: https://docs.github.com/en/github/using-git/setting-your-username-in-git
+.. _email: https://docs.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address
+.. _Fork: https://github.com/isentropic-dev/trnpy/fork
+.. _Clone: https://docs.github.com/en/github/getting-started-with-github/fork-a-repo#step-2-create-a-local-clone-of-your-fork

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Contributing
 
 For guidance on setting up a development environment and how to make a
-contribution to trnpy, see the `contributing guidelines`_.
+contribution to TrnPy, see the `contributing guidelines`_.
 
 .. _contributing guidelines: https://github.com/isentropic-dev/trnpy/blob/main/CONTRIBUTING.md
 

--- a/README.md
+++ b/README.md
@@ -2,48 +2,12 @@
 
 [![Build Status][test-badge]][main-test-workflow]
 
-## Development
+## Contributing
 
-When developing **trnpy**, it is recommended to set up a virtual environment.
-This ensures a clean and isolated environment for your development work.
-Here are the steps to initialize a virtual environment and install the requirements using `pip`:
+For guidance on setting up a development environment and how to make a
+contribution to trnpy, see the `contributing guidelines`_.
 
-### Prerequisites
-- Python 3.7 or above
-- `pip` package manager
-
-### Setting up a Virtual Environment
-1. Open a terminal or command prompt and navigate to the project directory.
-2. Create a new virtual environment by running the following command:
-
-```
-python3 -m venv env --prompt trnpy
-```
-
-This will create a new directory named `env` that contains the necessary files for the virtual environment.
-
-3. Activate the virtual environment:
-
-- On macOS and Linux:
-  ```
-  source env/bin/activate
-  ```
-- On Windows:
-  ```
-  env\Scripts\Activate.ps1
-  ```
-
-You should see `(trnpy)` at the beginning of your command prompt, indicating that the virtual environment is active.
-
-### Installing Requirements
-
-4. With the virtual environment activated, you can now install the project requirements:
-
-```
-pip install -e ".[lint,test,typing]"
-```
-
-This will install all the required packages specified in the `requirements.txt` file into your virtual environment.
+.. _contributing guidelines: https://github.com/isentropic-dev/trnpy/blob/main/CONTRIBUTING.md
 
 [test-badge]: https://github.com/isentropic-dev/trnpy/actions/workflows/test.yml/badge.svg
 [main-test-workflow]: https://github.com/isentropic-dev/trnpy/actions/workflows/test.yml?query=branch%3Amain+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
+
 [tool.isort]
 profile = "black"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [project]
 name = "trnpy"
-version = "0.0.1"
 authors = [
   { name = "John Dyreby", email = "john@isentropic.dev" },
   { name = "Greg Troszak", email = "greg@isentropic.dev" },
@@ -13,6 +12,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
+dynamic = ["version"]
 
 [project.urls]
 "Homepage" = "https://github.com/isentropic-dev/trnpy"
@@ -28,8 +28,11 @@ test = ["coverage >= 7.2.7", "pytest == 7.4.0"]
 typing = ["mypy == 1.5.1"]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Adds a GH action for publishing to PyPI. Pushs to `main` will always release a version to TestPyPI. Actual releases will only be triggered via GH releases.

I also decided to move pretty much everything in the README to a new CONTRIBUTING file, so we can better curate both, and not see a bunch of unnecessary stuff on PyPI.

I'll create a follow-up PR to consolidate the "Test" and "Lint" workflows. Right now, releases to TestPyPI are triggered the successful conclusion of the "Test" workflow. But the "Lint" workflow may have failed. The solution to this is to consolidate both of those into a single "CI" workflow that then triggers "Publish" on successful completion.
