### PR TITLE
Update TRNSYS lib loading and add stored values

### DIFF
--- a/src/trnpy/exceptions.py
+++ b/src/trnpy/exceptions.py
@@ -1,6 +1,13 @@
 from typing import Optional
 
 
+class UnsupportedOperatingSystem(Exception):
+    """Raised if this operating system is not supported."""
+
+    def __init__(self, system: str):
+        super().__init__(f"The {system} operating system is not supported by TRNSYS.")
+
+
 class DuplicateLibraryError(Exception):
     """Raised when a library file has already been loaded."""
 

--- a/src/trnpy/trnsys/lib.py
+++ b/src/trnpy/trnsys/lib.py
@@ -2,29 +2,16 @@
 
 import ctypes as ct
 import functools
-from dataclasses import dataclass
+import platform
 from pathlib import Path
-from typing import List, NamedTuple, Set
+from typing import List, NamedTuple, Optional, Set
 
-from ..exceptions import DuplicateLibraryError
-
-
-@dataclass
-class TrnsysDirectories:
-    """Represents the directory paths required by TRNSYS."""
-
-    root: Path
-    exe: Path
-    user_lib: Path
-
-    @classmethod
-    def from_single_path(cls, path: Path) -> "TrnsysDirectories":
-        """Create a TrnsysDirectories instance from a single path.
-
-        Args:
-            path (Path): The path to use for all TRNSYS directories.
-        """
-        return cls(path, path, path)
+from ..exceptions import (
+    DuplicateLibraryError,
+    TrnsysLoadInputFileError,
+    TrnsysSetDirectoriesError,
+    UnsupportedOperatingSystem,
+)
 
 
 class StepForwardReturn(NamedTuple):
@@ -35,6 +22,20 @@ class StepForwardReturn(NamedTuple):
         error (int): Error code reported by TRNSYS, with 0 indicating a successful call.
     """
 
+    done: bool
+    error: int
+
+
+class StepForwardWithValuesReturn(NamedTuple):
+    """The return value of `TrnsysLib.step_forward_with_values`.
+
+    Attributes:
+        values (List[float]): The stored values after stepping forward.
+        done (bool): True if the simulation has reached its final time.
+        error (int): Error code reported by TRNSYS, with 0 indicating a successful call.
+    """
+
+    values: List[float]
     done: bool
     error: int
 
@@ -63,18 +64,16 @@ class GetOutputValueReturn(NamedTuple):
     error: int
 
 
-def _track_lib_path(lib_path: Path, tracked_paths: Set[Path]) -> None:
-    """Track TRNSYS lib file paths.
+class StoredValueInfo(NamedTuple):
+    """Information about a stored value.
 
-    Raises:
-        DuplicateLibraryError: If the file at `lib_path` is already in use.
+    Attributes:
+        id (str): The unique identifier for this stored value.
+        label (str): The label associated with this stored value.
     """
-    if lib_path in tracked_paths:
-        raise DuplicateLibraryError(f"The TRNSYS lib '{lib_path}' is already loaded")
-    tracked_paths.add(lib_path)
 
-
-track_lib_path = functools.partial(_track_lib_path, tracked_paths=set())
+    id: str
+    label: str
 
 
 class TrnsysLib:
@@ -84,26 +83,11 @@ class TrnsysLib:
     that is responsible for loading and wrapping a TRNSYS library file.
     """
 
-    def set_directories(self, dirs: TrnsysDirectories) -> int:
-        """Set the TRNSYS directories.
-
-        Args:
-            dirs (TrnsysDirectories): The TRNSYS paths to set.
+    def get_stored_values_info(self) -> List[StoredValueInfo]:
+        """Return information about the stored values in this simulation.
 
         Returns:
-            int: The error code reported by TRNSYS, with 0 indicating a successful call.
-        """
-        raise NotImplementedError
-
-    def load_input_file(self, input_file: Path, type_lib_files: List[Path]) -> int:
-        """Load an input file.
-
-        Args:
-            input_file (Path): The TRNSYS input (deck) file to load.
-            type_lib_files (List[Path]): Type library files to load.
-
-        Returns:
-            int: The error code reported by TRNSYS, with 0 indicating a successful call.
+            StoredValuesInfo
         """
         raise NotImplementedError
 
@@ -115,6 +99,17 @@ class TrnsysLib:
 
         Returns:
             StepForwardReturn
+        """
+        raise NotImplementedError
+
+    def step_forward_with_values(self, steps: int) -> StepForwardWithValuesReturn:
+        """Step the simulation forward and return stored values.
+
+        Args:
+            steps (int): The number of steps to take.
+
+        Returns:
+            StepForwardWithValuesReturn
         """
         raise NotImplementedError
 
@@ -153,80 +148,48 @@ class TrnsysLib:
 
 
 class LoadedTrnsysLib(TrnsysLib):
-    """Represents a TRNSYS library loaded in memory."""
+    """Represents a loaded TRNSYS library ready to run a simulation."""
 
-    def __init__(self, lib_path: Path):
+    def __init__(
+        self,
+        trnsys_dir: Path,
+        input_file: Path,
+        user_type_libs: Optional[List[Path]] = None,
+    ):
         """Initialize a LoadedTrnsysLib object.
 
         Raises:
-            DuplicateLibraryError: If the file at `lib_path` is already in use.
+            UnsupportedOperatingSystem: If the OS is supported by TRNSYS.
+            DuplicateLibraryError: If the libs in `trnsys_dir` are already in use.
             OSError: If an error occurs when loading the library.
         """
-        track_lib_path(lib_path)
+        lib = _load_api_lib(trnsys_dir)
 
-        self.lib = ct.CDLL(str(lib_path), ct.RTLD_GLOBAL)
-        self.lib_path = lib_path
-
-        # Define the function signatures
-        self.lib.apiSetDirectories.argtypes = [
-            ct.c_char_p,  # root dir
-            ct.c_char_p,  # exe dir
-            ct.c_char_p,  # user lib dir
-            ct.POINTER(ct.c_int),  # error code (by reference)
-        ]
-        self.lib.apiLoadInputFile.argtypes = [
-            ct.c_char_p,  # input file
-            ct.c_char_p,  # semicolon-separated list of type lib files
-            ct.POINTER(ct.c_int),  # error code (by reference)
-        ]
-        self.lib.apiStepForward.restype = ct.c_bool
-        self.lib.apiStepForward.argtypes = [
-            ct.c_int,  # number of steps
-            ct.POINTER(ct.c_int),  # error code (by reference)
-        ]
-        self.lib.apiGetCurrentTime.restype = ct.c_double
-        self.lib.apiGetCurrentTime.argtypes = [
-            ct.POINTER(ct.c_int),  # error code (by reference)
-        ]
-        self.lib.apiGetOutputValue.restype = ct.c_double
-        self.lib.apiGetOutputValue.argtypes = [
-            ct.c_int,  # unit number
-            ct.c_int,  # output number
-            ct.POINTER(ct.c_int),  # error code (by reference)
-        ]
-        self.lib.apiSetInputValue.argtypes = [
-            ct.c_int,  # unit number
-            ct.c_int,  # input number
-            ct.c_double,  # value to set
-            ct.POINTER(ct.c_int),  # error code (by reference)
-        ]
-
-    def set_directories(self, dirs: TrnsysDirectories) -> int:
-        """Set the TRNSYS directories in the library.
-
-        Refer to the documentation of `TrnsysLib.set_directories` for more details.
-        """
         error = ct.c_int(0)
-        self.lib.apiSetDirectories(
-            str(dirs.root).encode(),
-            str(dirs.exe).encode(),
-            str(dirs.user_lib).encode(),
+        lib.apiSetDirectories(
+            str(trnsys_dir).encode(),
+            str(trnsys_dir).encode(),
+            str(trnsys_dir).encode(),
             error,
         )
-        return error.value
+        if error.value:
+            raise TrnsysSetDirectoriesError(error.value)
 
-    def load_input_file(self, input_file: Path, type_lib_files: List[Path]) -> int:
-        """Load an input file.
+        standard_types_lib = trnsys_dir / _lib_filename("types")
+        type_libs = [] if user_type_libs is None else user_type_libs
+        type_libs.append(standard_types_lib)
 
-        Refer to the documentation of `TrnsysLib.load_input_file` for more details.
-        """
-        error = ct.c_int(0)
-        self.lib.apiLoadInputFile(
+        lib.apiLoadInputFile(
             str(input_file).encode(),
-            ";".join(str(x) for x in type_lib_files).encode(),
+            ";".join(str(x) for x in type_libs).encode(),
             error,
         )
-        return error.value
+        if error.value:
+            raise TrnsysLoadInputFileError(error.value)
+
+        stored_values_count = lib.apiGetStoredValuesCount()
+        self.stored_values_buffer = (ct.c_double * stored_values_count)()
+        self.lib = lib
 
     def step_forward(self, steps: int) -> StepForwardReturn:
         """Step the simulation forward.
@@ -236,6 +199,19 @@ class LoadedTrnsysLib(TrnsysLib):
         error = ct.c_int(0)
         done = self.lib.apiStepForward(steps, error)
         return StepForwardReturn(done, error.value)
+
+    def step_forward_with_values(self, steps: int) -> StepForwardWithValuesReturn:
+        """Step the simulation forward and return stored values.
+
+        Refer to the documentation of `TrnsysLib.step_forward_with_values` for
+        more details.
+        """
+        error = ct.c_int(0)
+        done = self.lib.apiStepForwardWithValues(
+            steps, self.stored_values_buffer, error
+        )
+        values = list(self.stored_values_buffer)
+        return StepForwardWithValuesReturn(values, done, error.value)
 
     def get_current_time(self) -> GetCurrentTimeReturn:
         """Return the current time of the simulation.
@@ -263,3 +239,95 @@ class LoadedTrnsysLib(TrnsysLib):
         error = ct.c_int(0)
         self.lib.apiSetInputValue(unit, input_number, value, error)
         return error.value
+
+
+def _load_api_lib(trnsys_dir: Path) -> ct.CDLL:
+    """Load the TRNSYS API library.
+
+    Raises:
+        UnsupportedOperatingSystem: If this OS is not supported by TRNSYS.
+        DuplicateLibraryError: If the libs in `trnsys_dir` are already in use.
+        OSError: If an error occurs when loading the dynamic library.
+    """
+    api_lib = _lib_filename("api")
+    lib_path = trnsys_dir / api_lib
+    track_lib_path(lib_path)
+
+    lib = ct.CDLL(str(lib_path), ct.RTLD_GLOBAL)
+
+    # Define the function signatures
+    lib.apiSetDirectories.argtypes = [
+        ct.c_char_p,  # root dir
+        ct.c_char_p,  # exe dir
+        ct.c_char_p,  # user lib dir
+        ct.POINTER(ct.c_int),  # error code (by reference)
+    ]
+    lib.apiLoadInputFile.argtypes = [
+        ct.c_char_p,  # input file
+        ct.c_char_p,  # semicolon-separated list of type lib files
+        ct.POINTER(ct.c_int),  # error code (by reference)
+    ]
+    lib.apiGetStoredValuesCount.restype = ct.c_int
+    lib.apiGetStoredValuesInfo.restype = ct.c_char_p
+    lib.apiStepForward.restype = ct.c_bool
+    lib.apiStepForward.argtypes = [
+        ct.c_int,  # number of steps
+        ct.POINTER(ct.c_int),  # error code (by reference)
+    ]
+    lib.apiStepForwardWithValues.restype = ct.c_bool
+    lib.apiStepForwardWithValues.argtypes = [
+        ct.c_int,  # number of steps
+        ct.POINTER(ct.c_double),  # start of stored values array
+        ct.POINTER(ct.c_int),  # error code (by reference)
+    ]
+    lib.apiGetCurrentTime.restype = ct.c_double
+    lib.apiGetCurrentTime.argtypes = [
+        ct.POINTER(ct.c_int),  # error code (by reference)
+    ]
+    lib.apiGetOutputValue.restype = ct.c_double
+    lib.apiGetOutputValue.argtypes = [
+        ct.c_int,  # unit number
+        ct.c_int,  # output number
+        ct.POINTER(ct.c_int),  # error code (by reference)
+    ]
+    lib.apiSetInputValue.argtypes = [
+        ct.c_int,  # unit number
+        ct.c_int,  # input number
+        ct.c_double,  # value to set
+        ct.POINTER(ct.c_int),  # error code (by reference)
+    ]
+
+    return lib
+
+
+def _lib_filename(name: str) -> str:
+    """Return the system-specific filename for a dynamic library.
+
+    Args:
+        name(str): The name of the dynamic library.
+
+    Raises:
+        UnsupportedOperatingSystem: If this OS is not supported by TRNSYS.
+    """
+    filename = {
+        "Windows": f"{name}.dll",
+        "Darwin": f"lib{name}.dylib",
+        "Linux": f"lib{name}.so",
+    }.get(platform.system())
+    if filename is None:
+        raise UnsupportedOperatingSystem(platform.system())
+    return filename
+
+
+def _track_lib_path(lib_path: Path, tracked_paths: Set[Path]) -> None:
+    """Track TRNSYS lib file paths.
+
+    Raises:
+        DuplicateLibraryError: If the file at `lib_path` is already in use.
+    """
+    if lib_path in tracked_paths:
+        raise DuplicateLibraryError(f"The TRNSYS lib '{lib_path}' is already loaded")
+    tracked_paths.add(lib_path)
+
+
+track_lib_path = functools.partial(_track_lib_path, tracked_paths=set())

--- a/src/trnpy/trnsys/simulation.py
+++ b/src/trnpy/trnsys/simulation.py
@@ -11,7 +11,7 @@ from ..exceptions import (
     TrnsysSetInputValueError,
     TrnsysStepForwardError,
 )
-from .lib import LoadedTrnsysLib, TrnsysLib
+from .lib import LoadedTrnsysLib, StoredValueInfo, TrnsysLib
 
 
 class Simulation:
@@ -65,6 +65,21 @@ class Simulation:
     def __init__(self, lib: TrnsysLib):
         """Initialize a Simulation object."""
         self.lib = lib
+
+    def get_stored_values_info(self) -> List[StoredValueInfo]:
+        """Return information about the stored values in this simulation.
+
+        The order of the returned list of `StoredValueInfo` named tuples
+        corresponds to the order of stored values returned when calling
+        `Simulation.step_forward_with_values`.
+
+        Returns:
+            List[StoredValueInfo]: A list of named tuples with the following fields:
+                - id (str): The unique identifier for this stored value.
+                - label (str): The label associated with this stored value.
+        """
+        stored_values_info = self.lib.get_stored_values_info()
+        return stored_values_info
 
     def step_forward(self, steps: int = 1) -> bool:
         """Step the simulation forward.

--- a/src/trnpy/trnsys/simulation.py
+++ b/src/trnpy/trnsys/simulation.py
@@ -118,7 +118,6 @@ class Simulation:
         Args:
             steps (int, optional): The number of steps to take.  Defaults to 1.
 
-
         Returns:
             StepForwardWithValuesReturn: A named tuple with the following fields:
                 - values (List[float]): The stored values after stepping forward.

--- a/src/trnpy/trnsys/simulation.py
+++ b/src/trnpy/trnsys/simulation.py
@@ -3,17 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Union
+from typing import List, NamedTuple, Optional, Union
 
 from ..exceptions import (
     SimulationNotInitializedError,
     TrnsysGetOutputValueError,
-    TrnsysLoadInputFileError,
-    TrnsysSetDirectoriesError,
     TrnsysSetInputValueError,
     TrnsysStepForwardError,
 )
-from .lib import LoadedTrnsysLib, TrnsysDirectories, TrnsysLib
+from .lib import LoadedTrnsysLib, TrnsysLib
 
 
 class Simulation:
@@ -22,21 +20,20 @@ class Simulation:
     @classmethod
     def new(
         cls,
-        trnsys_lib: Union[str, Path],
-        type_lib_files: List[Union[str, Path]],
+        trnsys_dir: Union[str, Path],
         input_file: Union[str, Path],
-    ) -> "Simulation":
+        user_type_libs: Optional[List[Union[str, Path]]] = None,
+    ) -> Simulation:
         """Create a new TRNSYS simulation.
 
-        The directory containing the compiled TRNSYS library (`trnsys.dll`
-        for Windows, `libtrnsys.so` for Linux) must also contain the required
-        TRNSYS resource files (`Units.lab`, `Descrips.dat`, etc.).
+        The `trnsys_dir` must contain the compiled TRNSYS library (`trnsys.dll`
+        for Windows, `libtrnsys.so` for Linux) as well as the other required
+        libraries and resource files (`Units.lab`, `Descrips.dat`, etc.).
 
         Usage example:
-            trnsys_lib = "path/to/trnsys.dll"
-            type_lib_files = ["path/to/types.dll", "path/to/user_type.dll"]
+            trnsys_dir = "path/to/trnsys/directory"
             input_file = "path/to/example.dck"
-            sim = Simulation.new(trnsys_lib, type_lib_files, input_file)
+            sim = Simulation.new(trnsys_dir, input_file)
             done = False
             while not done:
                 done = sim.step_forward()
@@ -44,49 +41,30 @@ class Simulation:
                 print(f"Current value for output 1 of unit 7 is {value}")
 
         Args:
-            trnsys_lib: Path to the compiled TRNSYS library.
-            type_lib_files: List of paths to libraries containing Type subroutines.
+            trnsys_dir: Path to the TRNSYS directory.
             input_file: Path to the simulation's input (deck) file.
+            user_type_libs: Optional list of paths to user Type libs.
 
         Raises:
             FileNotFoundError: If the TRNSYS library or input file does not exist.
-            DuplicateLibraryError: The `trnsys_lib` file is already in use.
-            OSError: An error occurred loading `trnsys_lib`.
+            DuplicateLibraryError: The lib in `trnsys_dir` is already in use.
+            OSError: An error occurred loading the lib from `trnsys_dir`.
             TrnsysSetDirectoriesError
             TrnsysLoadInputFileError
         """
-        trnsys_lib = Path(trnsys_lib)
-        trnsys_lib_dir = trnsys_lib.parent  # use the lib's directory for all paths
-        return cls(
-            LoadedTrnsysLib(trnsys_lib),
-            [Path(x) for x in type_lib_files],
-            TrnsysDirectories(
-                root=trnsys_lib_dir,
-                exe=trnsys_lib_dir,
-                user_lib=trnsys_lib_dir,
-            ),
-            Path(input_file),
+        trnsys_dir = Path(trnsys_dir)
+        input_file = Path(input_file)
+        type_libs = (
+            []
+            if user_type_libs is None
+            else [Path(lib_file) for lib_file in user_type_libs]
         )
+        lib = LoadedTrnsysLib(trnsys_dir, input_file, type_libs)
+        return cls(lib)
 
-    def __init__(
-        self,
-        lib: TrnsysLib,
-        type_lib_files: List[Path],
-        dirs: TrnsysDirectories,
-        input_file: Path,
-    ):
+    def __init__(self, lib: TrnsysLib):
         """Initialize a Simulation object."""
-        error_code = lib.set_directories(dirs)
-        if error_code:
-            raise TrnsysSetDirectoriesError(error_code)
-
-        error_code = lib.load_input_file(input_file, type_lib_files)
-        if error_code:
-            raise TrnsysLoadInputFileError(error_code)
-
         self.lib = lib
-        self.dirs = dirs
-        self.input_file = input_file
 
     def step_forward(self, steps: int = 1) -> bool:
         """Step the simulation forward.
@@ -104,7 +82,7 @@ class Simulation:
 
         Raises:
             ValueError: If `steps` is less than 1.
-            TrnsysStepForwardError
+            TrnsysStepForwardError: If a simulation error occurs while stepping forward.
         """
         if steps < 1:
             raise ValueError("Number of steps cannot be less than 1.")
@@ -114,6 +92,34 @@ class Simulation:
             raise TrnsysStepForwardError(error_code)
 
         return done
+
+    def step_forward_with_values(self, steps: int = 1) -> StepForwardWithValuesReturn:
+        """Step the simulation forward and return stored values.
+
+        It is not possible to step a simulation beyond its final time.  Fewer
+        steps than the requested number will be taken if `steps` is greater
+        than the number of steps remaining in the simulation.
+
+        Args:
+            steps (int, optional): The number of steps to take.  Defaults to 1.
+
+
+        Returns:
+            StepForwardWithValuesReturn: A named tuple with the following fields:
+                - values (List[float]): The stored values after stepping forward.
+                - done (bool): True if the simulation has reached its final time.
+        Raises:
+            ValueError: If `steps` is less than 1.
+            TrnsysStepForwardError: If a simulation error occurs while stepping forward.
+        """
+        if steps < 1:
+            raise ValueError("Number of steps cannot be less than 1.")
+
+        (values, done, error_code) = self.lib.step_forward_with_values(steps)
+        if error_code:
+            raise TrnsysStepForwardError(error_code)
+
+        return StepForwardWithValuesReturn(values, done)
 
     def get_current_time(self) -> float:
         """Return the current time of the simulation.
@@ -163,3 +169,15 @@ class Simulation:
         error_code = self.lib.set_input_value(unit, input_number, value)
         if error_code:
             raise TrnsysSetInputValueError(error_code)
+
+
+class StepForwardWithValuesReturn(NamedTuple):
+    """The return value of `Simulation.step_forward_with_values`.
+
+    Attributes:
+        values (List[float]): The stored values after stepping forward.
+        done (bool): True if the simulation has reached its final time.
+    """
+
+    values: List[float]
+    done: bool

--- a/tests/test_trnsys.py
+++ b/tests/test_trnsys.py
@@ -14,7 +14,6 @@ from trnpy.exceptions import (
 from trnpy.trnsys.lib import (
     GetOutputValueReturn,
     StepForwardReturn,
-    TrnsysDirectories,
     TrnsysLib,
     track_lib_path,
 )
@@ -73,12 +72,6 @@ class MockTrnsysLib(TrnsysLib):
         """
         return abs(self._final_time - self._current_time) < 0.5 * self._time_step
 
-    def set_directories(self, dirs: TrnsysDirectories) -> int:
-        return 0
-
-    def load_input_file(self, input_file: Path, type_lib_files: List[Path]) -> int:
-        return 0
-
     def step_forward(self, steps: int) -> StepForwardReturn:
         if self._is_at_final_time():
             return StepForwardReturn(False, 1)
@@ -112,10 +105,7 @@ def new_sim(*, lib_state: Optional[Dict[str, Any]] = None):
         lib_state (dict, optional): If provided, passed directly to `MockTrnsysLib`.
     """
     lib = MockTrnsysLib(**(lib_state if lib_state else {}))
-    type_libs: List[Path] = []
-    dirs = TrnsysDirectories.from_single_path(Path(""))
-    input_file = Path("")
-    return Simulation(lib, type_libs, dirs, input_file)
+    return Simulation(lib)
 
 
 def test_track_lib_path_raises_duplicate_error_on_same_path():


### PR DESCRIPTION
This PR adds functionality related to the concept of stored values that were added to the TRNSYS kernel.  In doing so, I had to make a few adjustments related to other changes that were made in the kernel.  The result of these changes is a simplified `Simulation` object, but there are breaking changes for how it is created.  But since there are only a handful of folks using this library right now I think this is ok, and I will ensure the UW ESOL students are aware of the changes.

The biggest change was recognizing that while a `LoadedTrnsysLib` can be created independently before loading an input (deck) file, almost all of its functionality requires that a deck be loaded.  By requiring an input file to be loaded as part of creating a `LoadedTrnsysLib`, we can ensure that the API functions work as expected.  More relevant to the stored values, it allows us to keep the array buffer local to the `LoadedTrnsysLib`, which makes the most sense.  Creating the array buffer where stored values are written by the kernel requires us to know how many stored values there are, which is only known after a deck is loaded.

Previously, the `Simulation` was responsible for setting directories and loading the input file.  Now a `Simulation` is initialized with a `LoadedTrnsysLib` that already has a deck ready to go, so we can remove the `set_directories` and `load_input_file` methods on `TrnsysLib`.


Resolves #61
Resolves #66

