### PR TITLE
Use new kernel API

### DIFF
--- a/src/trnpy/exceptions.py
+++ b/src/trnpy/exceptions.py
@@ -26,26 +26,18 @@ class TrnsysError(Exception):
         self.error_code = error_code
 
 
-class TrnsysSetDirectoriesError(TrnsysError):
+class TrnsysInitializeSimulationError(TrnsysError):
     def __init__(self, error_code: int):
         messages = {
-            1: "root directory string is too long",
-            2: "root directory does not exist",
-            3: "exe directory string is too long",
-            4: "exe directory does not exist",
-            5: "user lib directory string is too long",
-            6: "user lib directory does not exist",
-        }
-        super().__init__(error_code, messages.get(error_code))
-
-
-class TrnsysLoadInputFileError(TrnsysError):
-    def __init__(self, error_code: int):
-        messages = {
-            1: "input file does not exist",
-            2: "directories not set",
-            3: "list file cannot be opened for writing",
-            4: "input file cannot be opened for reading",
+            1: "provided config is not valid",
+            2: "a specified file or directory does not exist",
+            3: "standard Types library was not found",
+            4: "simulation has already been initialized",
+            5: "list file cannot be opened for writing",
+            6: "input file cannot be opened for reading",
+            7: "a required Type was not found",
+            8: "an invalid stored value was specified in the input file",
+            100: "license is expired",
         }
         super().__init__(error_code, messages.get(error_code))
 

--- a/src/trnpy/trnsys/lib.py
+++ b/src/trnpy/trnsys/lib.py
@@ -53,18 +53,6 @@ class GetFloatReturn(NamedTuple):
     error: int
 
 
-class GetIntReturn(NamedTuple):
-    """The return value of a `TrnsysLib` function that returns an `int`.
-
-    Attributes:
-        value (int): The value returned by TRNSYS.
-        error (int): Error code reported by TRNSYS, with 0 indicating a successful call.
-    """
-
-    value: int
-    error: int
-
-
 class StoredValueInfo(NamedTuple):
     """Information about a stored value.
 
@@ -114,51 +102,51 @@ class TrnsysLib:
         """
         raise NotImplementedError
 
-    def get_current_time(self) -> GetFloatReturn:
+    def get_current_time(self) -> float:
         """Return the current time of the simulation.
 
         Returns:
-            GetFloatReturn
+            float: The current time of the simulation.
         """
         raise NotImplementedError
 
-    def get_start_time(self) -> GetFloatReturn:
+    def get_start_time(self) -> float:
         """Return the start time of the simulation.
 
         Returns:
-            GetFloatReturn
+            float: The start time of the simulation.
         """
         raise NotImplementedError
 
-    def get_stop_time(self) -> GetFloatReturn:
+    def get_stop_time(self) -> float:
         """Return the stop time of the simulation.
 
         Returns:
-            GetFloatReturn
+            float: The stop time of the simulation.
         """
         raise NotImplementedError
 
-    def get_time_step(self) -> GetFloatReturn:
+    def get_time_step(self) -> float:
         """Return the time step of the simulation.
 
         Returns:
-            GetFloatReturn
+            float: The time step of the simulation.
         """
         raise NotImplementedError
 
-    def get_current_step(self) -> GetIntReturn:
+    def get_current_step(self) -> int:
         """Return the current step of the simulation.
 
         Returns:
-            GetIntReturn
+            int: The current step of the simulation.
         """
         raise NotImplementedError
 
-    def get_total_steps(self) -> GetIntReturn:
+    def get_total_steps(self) -> int:
         """Return the total number of steps in the simulation.
 
         Returns:
-            GetIntReturn
+            int: The total number of steps of the simulation.
         """
         raise NotImplementedError
 
@@ -270,59 +258,47 @@ class LoadedTrnsysLib(TrnsysLib):
         values = list(self.stored_values_buffer)
         return StepForwardWithValuesReturn(values, done, error.value)
 
-    def get_current_time(self) -> GetFloatReturn:
+    def get_current_time(self) -> float:
         """Return the current time of the simulation.
 
         Refer to the documentation of `TrnsysLib.get_current_time` for more details.
         """
-        error = ct.c_int(0)
-        value = self.lib.apiGetCurrentTime(error)
-        return GetFloatReturn(value, error.value)
+        return self.lib.apiGetCurrentTime()
 
-    def get_start_time(self) -> GetFloatReturn:
+    def get_start_time(self) -> float:
         """Return the start time of the simulation.
 
         Refer to the documentation of `TrnsysLib.get_start_time` for more details.
         """
-        error = ct.c_int(0)
-        value = self.lib.apiGetStartTime(error)
-        return GetFloatReturn(value, error.value)
+        return self.lib.apiGetStartTime()
 
-    def get_stop_time(self) -> GetFloatReturn:
+    def get_stop_time(self) -> float:
         """Return the stop time of the simulation.
 
         Refer to the documentation of `TrnsysLib.get_stop_time` for more details.
         """
-        error = ct.c_int(0)
-        value = self.lib.apiGetStopTime(error)
-        return GetFloatReturn(value, error.value)
+        return self.lib.apiGetStopTime()
 
-    def get_time_step(self) -> GetFloatReturn:
+    def get_time_step(self) -> float:
         """Return the time step of the simulation.
 
         Refer to the documentation of `TrnsysLib.get_time_step` for more details.
         """
-        error = ct.c_int(0)
-        value = self.lib.apiGetTimeStep(error)
-        return GetFloatReturn(value, error.value)
+        return self.lib.apiGetTimeStep()
 
-    def get_current_step(self) -> GetIntReturn:
+    def get_current_step(self) -> int:
         """Return the current step of the simulation.
 
         Refer to the documentation of `TrnsysLib.get_current_step` for more details.
         """
-        error = ct.c_int(0)
-        value = self.lib.apiGetCurrentStep(error)
-        return GetIntReturn(value, error.value)
+        return self.lib.apiGetCurrentStep()
 
-    def get_total_steps(self) -> GetIntReturn:
+    def get_total_steps(self) -> int:
         """Return the total number of steps in the simulation.
 
         Refer to the documentation of `TrnsysLib.get_total_steps` for more details.
         """
-        error = ct.c_int(0)
-        value = self.lib.apiGetTotalSteps(error)
-        return GetIntReturn(value, error.value)
+        return self.lib.apiGetTotalSteps()
 
     def get_output_value(self, unit: int, output_number: int) -> GetFloatReturn:
         """Return the output value of a unit.
@@ -402,22 +378,11 @@ def _load_api_lib(trnsys_dir: Path) -> ct.CDLL:
     ]
 
     lib.apiGetCurrentTime.restype = ct.c_double
-    lib.apiGetCurrentTime.argtypes = [ct.POINTER(ct.c_int)]
-
     lib.apiGetStartTime.restype = ct.c_double
-    lib.apiGetStartTime.argtypes = [ct.POINTER(ct.c_int)]
-
     lib.apiGetStopTime.restype = ct.c_double
-    lib.apiGetStopTime.argtypes = [ct.POINTER(ct.c_int)]
-
     lib.apiGetTimeStep.restype = ct.c_double
-    lib.apiGetTimeStep.argtypes = [ct.POINTER(ct.c_int)]
-
     lib.apiGetCurrentStep.restype = ct.c_int
-    lib.apiGetCurrentStep.argtypes = [ct.POINTER(ct.c_int)]
-
     lib.apiGetTotalSteps.restype = ct.c_int
-    lib.apiGetTotalSteps.argtypes = [ct.POINTER(ct.c_int)]
 
     return lib
 

--- a/src/trnpy/trnsys/lib.py
+++ b/src/trnpy/trnsys/lib.py
@@ -251,42 +251,42 @@ class LoadedTrnsysLib(TrnsysLib):
 
         Refer to the documentation of `TrnsysLib.get_current_time` for more details.
         """
-        return self.lib.apiGetCurrentTime()
+        return float(self.lib.apiGetCurrentTime())
 
     def get_start_time(self) -> float:
         """Return the start time of the simulation.
 
         Refer to the documentation of `TrnsysLib.get_start_time` for more details.
         """
-        return self.lib.apiGetStartTime()
+        return float(self.lib.apiGetStartTime())
 
     def get_stop_time(self) -> float:
         """Return the stop time of the simulation.
 
         Refer to the documentation of `TrnsysLib.get_stop_time` for more details.
         """
-        return self.lib.apiGetStopTime()
+        return float(self.lib.apiGetStopTime())
 
     def get_time_step(self) -> float:
         """Return the time step of the simulation.
 
         Refer to the documentation of `TrnsysLib.get_time_step` for more details.
         """
-        return self.lib.apiGetTimeStep()
+        return int(self.lib.apiGetTimeStep())
 
     def get_current_step(self) -> int:
         """Return the current step of the simulation.
 
         Refer to the documentation of `TrnsysLib.get_current_step` for more details.
         """
-        return self.lib.apiGetCurrentStep()
+        return int(self.lib.apiGetCurrentStep())
 
     def get_total_steps(self) -> int:
         """Return the total number of steps in the simulation.
 
         Refer to the documentation of `TrnsysLib.get_total_steps` for more details.
         """
-        return self.lib.apiGetTotalSteps()
+        return int(self.lib.apiGetTotalSteps())
 
     def get_output_value(self, unit: int, output_number: int) -> GetFloatReturn:
         """Return the output value of a unit.

--- a/src/trnpy/trnsys/simulation.py
+++ b/src/trnpy/trnsys/simulation.py
@@ -166,32 +166,32 @@ class Simulation:
     @property
     def current_time(self) -> float:
         """The current time of the simulation."""
-        return self.lib.get_current_time().value
+        return self.lib.get_current_time()
 
     @property
     def current_step(self) -> int:
         """The current step of the simulation."""
-        return self.lib.get_current_step().value
+        return self.lib.get_current_step()
 
     @property
     def start_time(self) -> float:
         """The start time of the simulation."""
-        return self.lib.get_start_time().value
+        return self.lib.get_start_time()
 
     @property
     def stop_time(self) -> float:
         """The stop time of the simulation."""
-        return self.lib.get_stop_time().value
+        return self.lib.get_stop_time()
 
     @property
     def time_step(self) -> float:
         """The time step of the simulation."""
-        return self.lib.get_time_step().value
+        return self.lib.get_time_step()
 
     @property
     def total_steps(self) -> int:
         """The total number of time steps in the simulation."""
-        return self.lib.get_total_steps().value
+        return self.lib.get_total_steps()
 
 
 class StepForwardWithValuesReturn(NamedTuple):


### PR DESCRIPTION
The TRNSYS kernel API was changed.

- Some TRNSYS getter functions no longer take an argument
- Use apiInitializeSimulation function to simplify loading a deck

Resolves #90 